### PR TITLE
Update imagemin peerDependencies package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "loader-utils": "^1.1.0"
   },
   "peerDependencies": {
-    "imagemin": "^5.0.0 || ^6.0.0"
+    "imagemin": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "file-loader": "^4.0.0",


### PR DESCRIPTION
PR #44 updates `imagemin` to v7 but `package.json` is missing under peerDependencies.

Closes #49 