### PR TITLE
Update package loader-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1
+
+Update loader-utils as 1.1.0 is vulnerable to Regular Expression Denial of Service vie url variable. Which is patched in loader-utils >=1.4.2
+
 ## 4.0.0
 
 **Breaking Change** Require Node 12+.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "img-loader",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Image minimizing loader for webpack 4",
   "keywords": [
     "image",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/vanwagonet/img-loader",
   "dependencies": {
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^3.2.1"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable
It is patched in >=1.4.2

Updated loader-utils version in package.json to 3.2.1